### PR TITLE
MS1 quant speed up and a few misc additions

### DIFF
--- a/config.py
+++ b/config.py
@@ -29,7 +29,10 @@ parser.add_argument('--timspeak_file', default="", type=str)
 parser.add_argument('--lib_frac', default=.5, type=float)
 parser.add_argument('-z','--dummy_value', type=str)
 parser.add_argument('--plexDIA', action='store_true')
-parser.add_argument('--use_emp_rt', action='store_true')
+parser.add_argument('--use_emp_rt', action='store_true') #use original library RTs
+parser.add_argument('--unfiltered_quant', action='store_false') #by default it will only do MS1 quant on precursors with best channel qvalue < 0.01
+parser.add_argument('--score_lib_frac', default=.5, type=float) #minimum frac_lib_int that a precursor must have to score
+parser.add_argument('--no_transfer', action='store_true') #by default use shared channel information for precursor scoring
 
 
 


### PR DESCRIPTION
1. Removed decoys from MS1 quant (this speeds up considerably) and only quantify 1% FDR be default. Use --unfiltered_quant for all. 
- Verified that any new features generated in MS1 quant are removed from consideration in target/decoy classification.

2. Incorporated parser.add_argument('--score_lib_frac', default=.5, type=float) #minimum frac_lib_int that a precursor must have to score 
- This sets the minimum frac_lib_int to be used in target/decoy classification. This is so we can set lib_frac to a lower value without harming target/decoy classification (if that would have happened).

3. Included protein q value calculation. Entrapped FDR seems to remain controlled even in 3x3 timeplex plexDIA.

4. Included a new column "BestChannel_Qvalue" which looks across run (timeplex'es and plexDIA) and gives the lowest q value.

5. Added the following: parser.add_argument('--no_transfer', action='store_true') #by default use shared channel information for precursor scoring
- For cases where there is not reasonable expectation that precursors should be shared across plexes, you can disable using shared channel information (no transferred identifications). Feel free to re-name.